### PR TITLE
bug fix: close S3Directory GetObject download stream

### DIFF
--- a/pkg/bluge/directory/s3.go
+++ b/pkg/bluge/directory/s3.go
@@ -158,6 +158,11 @@ func (s *S3Directory) Load(kind string, id uint64) (*segment.Data, io.Closer, er
 		log.Print("Load: failed to get object: s3://"+s.Bucket+"/"+key, err.Error())
 		return nil, nil, err
 	}
+	defer func() {
+		if err := output.Body.Close(); err != nil {
+			log.Print("Load: failed to close download stream: s3://"+s.Bucket+"/"+key, err.Error())
+		}
+	}()
 
 	data, err := ioutil.ReadAll(output.Body)
 	if err != nil {


### PR DESCRIPTION
I had goroutine leaks and tcp connection leaks when using S3Directory. The reason turned out to be that the `output` returned by GetObject in S3Directory.Load forgot to close, which is a wrapper of `*http.Response`.