### PR TITLE
added missing routes to make es apis compatible for bulk index on a g…

### DIFF
--- a/pkg/handlers/document/bulk.go
+++ b/pkg/handlers/document/bulk.go
@@ -132,9 +132,16 @@ func BulkWorker(target string, body io.Reader) (*BulkResponse, error) {
 			} else {
 				update = true
 			}
-
-			indexName := lastLineMetaData["_index"].(string)
-			operation := lastLineMetaData["operation"].(string)
+			suppliedIndexName := lastLineMetaData["_index"]
+			if suppliedIndexName == nil && len(target) > 0 {
+				suppliedIndexName = target
+			}
+			suppliedOperation := lastLineMetaData["operation"]
+			if suppliedOperation == nil && len(target) > 0 {
+				suppliedOperation = "create"
+			}
+			indexName := suppliedIndexName.(string)
+			operation := suppliedOperation.(string)
 			switch operation {
 			case "index":
 				bulkRes.Items = append(bulkRes.Items, map[string]BulkResponseItem{
@@ -206,6 +213,9 @@ func BulkWorker(target string, body io.Reader) (*BulkResponse, error) {
 					bulkRes.Items = append(bulkRes.Items, map[string]BulkResponseItem{
 						"delete": NewBulkResponseItem(bulkRes.Count, indexName, docID, "deleted", err),
 					})
+				} else {
+					lastLineMetaData["_index"] = target
+					lastLineMetaData["operation"] = "index"
 				}
 			}
 		}

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -187,6 +187,8 @@ func SetRoutes(r *gin.Engine) {
 	// ES Bulk update/insert
 	r.POST("/es/_bulk", AuthMiddleware("document.ESBulk"), ESMiddleware, document.ESBulk)
 	r.POST("/es/:target/_bulk", AuthMiddleware("document.ESBulk"), ESMiddleware, document.ESBulk)
+	r.PUT("/es/:target/_bulk", AuthMiddleware("document.ESBulk"), ESMiddleware, document.ESBulk)
+	r.POST("/es/:target/_refresh", AuthMiddleware("index.Refresh"), index.Refresh)
 	// ES Document
 	r.POST("/es/:target/_doc", AuthMiddleware("document.CreateUpdate"), ESMiddleware, document.CreateUpdate)        // create
 	r.PUT("/es/:target/_doc/:id", AuthMiddleware("document.CreateUpdate"), ESMiddleware, document.CreateUpdate)     // create or update


### PR DESCRIPTION
The elasticsearch spark connectors were unable to write into zincsearch because a couple of endpoints were missing. We have done minimal changes required to make it work by adding below two endpoints - 

1. r.PUT("/es/:target/_bulk", AuthMiddleware("document.ESBulk"), ESMiddleware, document.ESBulk)
2. r.POST("/es/:target/_refresh", AuthMiddleware("index.Refresh"), index.Refresh)

This change is another step towards making zincsearch closer to es apis for such clients. 